### PR TITLE
Add support for utf-8, fix newline

### DIFF
--- a/vcard2csv.py
+++ b/vcard2csv.py
@@ -148,7 +148,7 @@ def main():
         sys.exit(2)
 
     # Tab separated values are less annoying than comma-separated values.
-    with open(args.tsv_file, 'w') as tsv_fp:
+    with open(args.tsv_file, 'w', encoding="utf-8", newline='') as tsv_fp:
         writer = csv.writer(tsv_fp, delimiter='\t')
         writer.writerow(column_order)
 


### PR DESCRIPTION
Fix error when vcard contains utf-8 characters.
Remove empty line after each row on windows. Solution from https://stackoverflow.com/questions/3191528/csv-in-python-adding-an-extra-carriage-return-on-windows